### PR TITLE
Require barry >= 0.2.2 (hash-collision fix) and make init_defm interruptible

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -36,7 +36,11 @@ jobs:
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from the
+          # barryr PR branch. Remove once barryr 0.2.2 is released
+          # (USCbiostats/barryr#8).
           extra-packages: |
             any::rcmdcheck
             any::tinytest
+            USCbiostats/barryr@fix/freqtable-hash-collisions
           needs: check

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -36,11 +36,10 @@ jobs:
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from the
-          # barryr PR branch. Remove once barryr 0.2.2 is released
-          # (USCbiostats/barryr#8).
+          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from
+          # barryr's main branch. Remove once barry 0.2.2 is on CRAN.
           extra-packages: |
             any::rcmdcheck
             any::tinytest
-            USCbiostats/barryr@fix/freqtable-hash-collisions
+            USCbiostats/barryr
           needs: check

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -20,12 +20,11 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from the
-          # barryr PR branch. Remove once barryr 0.2.2 is released
-          # (USCbiostats/barryr#8).
+          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from
+          # barryr's main branch. Remove once barry 0.2.2 is on CRAN.
           extra-packages: |
             any::covr
-            USCbiostats/barryr@fix/freqtable-hash-collisions
+            USCbiostats/barryr
           needs: check
 
       - name: Running coverage

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -20,8 +20,12 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from the
+          # barryr PR branch. Remove once barryr 0.2.2 is released
+          # (USCbiostats/barryr#8).
           extra-packages: |
             any::covr
+            USCbiostats/barryr@fix/freqtable-hash-collisions
           needs: check
 
       - name: Running coverage

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -41,9 +41,13 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from the
+          # barryr PR branch. Remove once barryr 0.2.2 is released
+          # (USCbiostats/barryr#8).
           extra-packages: |
             any::pkgdown
             local::.
+            USCbiostats/barryr@fix/freqtable-hash-collisions
           needs: website
 
       - name: Build site

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -41,13 +41,12 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from the
-          # barryr PR branch. Remove once barryr 0.2.2 is released
-          # (USCbiostats/barryr#8).
+          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from
+          # barryr's main branch. Remove once barry 0.2.2 is on CRAN.
           extra-packages: |
             any::pkgdown
             local::.
-            USCbiostats/barryr@fix/freqtable-hash-collisions
+            USCbiostats/barryr
           needs: website
 
       - name: Build site

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -25,6 +25,13 @@ jobs:
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from the
+          # barryr PR branch. Remove once barryr 0.2.2 is released
+          # (USCbiostats/barryr#8). The DESCRIPTION Remotes field is not
+          # honored by pak's `deps::.`, so the source must be listed here.
+          extra-packages: |
+            USCbiostats/barryr@fix/freqtable-hash-collisions
 
       - name: Build package
         run: R CMD build .
@@ -73,8 +80,12 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from the
+          # barryr PR branch. Remove once barryr 0.2.2 is released
+          # (USCbiostats/barryr#8).
           extra-packages: |
             any::rcmdcheck
+            USCbiostats/barryr@fix/freqtable-hash-collisions
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -26,12 +26,12 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from the
-          # barryr PR branch. Remove once barryr 0.2.2 is released
-          # (USCbiostats/barryr#8). The DESCRIPTION Remotes field is not
-          # honored by pak's `deps::.`, so the source must be listed here.
+          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from
+          # barryr's main branch. Remove once barry 0.2.2 is on CRAN.
+          # (The DESCRIPTION Remotes field is not honored by pak's
+          # `deps::.`, so the source must be listed here.)
           extra-packages: |
-            USCbiostats/barryr@fix/freqtable-hash-collisions
+            USCbiostats/barryr
 
       - name: Build package
         run: R CMD build .
@@ -80,12 +80,11 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from the
-          # barryr PR branch. Remove once barryr 0.2.2 is released
-          # (USCbiostats/barryr#8).
+          # TEMPORARY: barry (>= 0.2.2) is not on CRAN yet; pull it from
+          # barryr's main branch. Remove once barry 0.2.2 is on CRAN.
           extra-packages: |
             any::rcmdcheck
-            USCbiostats/barryr@fix/freqtable-hash-collisions
+            USCbiostats/barryr
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,3 +32,5 @@ Depends:
     stats4
 Suggests: 
     texreg, tinytest, barry
+Remotes:
+    USCbiostats/barryr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: defm
 Type: Package
 Title: Estimation and Simulation of Multi-Binary Response Models
-Version: 0.2.1.0
+Version: 0.2.2.0
 Authors@R: c(
     person("George", "Vega Yon", role=c("aut", "cre"),
     email="g.vegayon@gmail.com", comment = c(ORCID = "0000-0002-3171-0844")),
@@ -23,7 +23,7 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
-LinkingTo: Rcpp, barry
+LinkingTo: Rcpp, barry (>= 0.2.2)
 Imports: 
     Rcpp,
     stats

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# defm 0.2.2.0
+
+* Requires `barry` (>= 0.2.2), which fixes a hash-collision bug that made
+  `init_defm()` appear to hang for models with many outcome columns
+  (USCbiostats/barry#24). A 16-outcome model that previously never finished
+  initializing now takes seconds.
+
+* Long-running computations (e.g., the support enumeration in `init_defm()`)
+  can now be interrupted from R with Ctrl-C. Note that a model interrupted
+  mid-initialization is left partially initialized and should be rebuilt
+  with `new_defm()` before further use.
+
+
 # defm 0.2.1.0
 
 * Returning to CRAN.

--- a/src/counters.cpp
+++ b/src/counters.cpp
@@ -1,4 +1,9 @@
 #include <Rcpp.h>
+
+// Lets barry check for user interrupts (Ctrl-C) during long-running
+// computations such as the support enumeration in init_defm().
+#define BARRY_USER_INTERRUPT Rcpp::checkUserInterrupt();
+
 #include <barry/barry.hpp>
 #include <barry/models/defm.hpp>
 

--- a/src/defm-object.cpp
+++ b/src/defm-object.cpp
@@ -1,4 +1,9 @@
 #include <Rcpp.h>
+
+// Lets barry check for user interrupts (Ctrl-C) during long-running
+// computations such as the support enumeration in init_defm().
+#define BARRY_USER_INTERRUPT Rcpp::checkUserInterrupt();
+
 #include <barry/barry.hpp>
 #include <barry/models/defm.hpp>
 

--- a/src/terms.cpp
+++ b/src/terms.cpp
@@ -1,4 +1,9 @@
 #include <Rcpp.h>
+
+// Lets barry check for user interrupts (Ctrl-C) during long-running
+// computations such as the support enumeration in init_defm().
+#define BARRY_USER_INTERRUPT Rcpp::checkUserInterrupt();
+
 #include "barry/barry.hpp"
 #include "barry/models/defm.hpp"
 #include "defm-common.h"


### PR DESCRIPTION
## Summary

Companion to USCbiostats/barry#24 and USCbiostats/barryr#8, which fix a catastrophic hash-collision bug in barry's `FreqTable`/`vecHasher`: support statistics (small-integer doubles) produced hashes with no entropy in their low bits, so `unordered_map` chained every key in a single bucket and support enumeration degraded from O(2^ncol) to O(4^ncol). In defm terms, `init_defm()` on a 16-outcome, order-1 panel model appeared to hang forever (~14 s *per unique Markov state* before, ~0.05 s after; a 20-state synthetic case went from >5 min to under a second). This PR:

1. **Requires `barry (>= 0.2.2)` in `LinkingTo`** so defm is compiled against the fixed headers (verified: `R CMD INSTALL` correctly refuses to build against barry 0.2.1).
2. **Defines `BARRY_USER_INTERRUPT` as `Rcpp::checkUserInterrupt()`** in every translation unit that includes barry, enabling barry's built-in interrupt checkpoint (every 1000 support iterations). Long `init_defm()` calls can now be stopped with Ctrl-C instead of force-killing R — this was the other half of the original report ("computer hangs and Ctrl-C does nothing").
3. Bumps version to 0.2.2.0 (tracking barry's versioning) with a NEWS entry.

## Verification

- All 25 tinytest results pass against barry 0.2.2.
- Interrupt hook verified via `setTimeLimit(elapsed = 3)`, which fires at the same `R_CheckUserInterrupt` checkpoint as Ctrl-C: a ~20 s `init_defm()` aborts at ~3 s with a clean R error (`reached elapsed time limit`), no crash or corruption on unwind. Plain `Rscript` ignores SIGINT entirely (verified with a pure-R loop baseline), so the time-limit route is the reliable non-interactive proxy.
- Timing unchanged on the support-enumeration benchmark (interrupt check adds no measurable overhead: 16-col/20-state init ~0.7 s, same as without the hook).
- Note: a model interrupted mid-`init_defm()` is left partially initialized and should be rebuilt with `new_defm()` before reuse — same caveat as any error thrown during init (documented in NEWS).

**Merge order:** needs barry ≥ 0.2.2 available (USCbiostats/barry#24 → USCbiostats/barryr#8 → this); CI will fail to satisfy `LinkingTo` until the barryr release is on CRAN/r-universe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)